### PR TITLE
Add SRG and Mojmap aliases for OptionListWidgetMixin8.optionsScreen

### DIFF
--- a/src/main/java/com/hamarb123/macos_input_fixes/mixin/gui/OptionListWidgetMixin8.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/mixin/gui/OptionListWidgetMixin8.java
@@ -13,7 +13,8 @@ import net.minecraft.client.option.SimpleOption;
 @Mixin(OptionListWidget.class)
 public class OptionListWidgetMixin8
 {
-	@Shadow(remap = false, aliases = {"field_49483", "optionsScreen"})
+	// Intermediary, Yarn, SRG, Mojmap
+	@Shadow(remap = false, aliases = {"field_49483", "optionsScreen", "f_316801_", "screen"})
 	private GameOptionsScreen optionsScreen;
 
 	//this is where we add additional menu options

--- a/src/main/java/com/hamarb123/macos_input_fixes/mixin/gui/OptionListWidgetMixin8.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/mixin/gui/OptionListWidgetMixin8.java
@@ -13,7 +13,7 @@ import net.minecraft.client.option.SimpleOption;
 @Mixin(OptionListWidget.class)
 public class OptionListWidgetMixin8
 {
-	// Intermediary, Yarn, SRG, Mojmap
+	//Intermediary, Yarn, SRG, Mojmap
 	@Shadow(remap = false, aliases = {"field_49483", "optionsScreen", "f_316801_", "screen"})
 	private GameOptionsScreen optionsScreen;
 


### PR DESCRIPTION
Allows running the mod properly on NeoForge (via [Sinytra Connector](https://github.com/Sinytra/Connector)), which uses some weird amalgamation of Mojmap and SRG during runtime (to my recollection). More specifically, it fixes a crash on 1.21(.1) when opening the "Controls" options menu.