### PR TITLE
Mark mod as client only in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
 	"license": "BSD-3-Clause",
 	"icon": "assets/macos_input_fixes/icon.png",
 
-	"environment": "*",
+	"environment": "client",
 	"entrypoints":
 	{
 		"main":


### PR DESCRIPTION
This prevents some crashes when this mod is accidentally installed on a server.