### PR TITLE
Fix compatibility with Minecraft 1.21.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you make changes, you should test everything works properly on the following 
 - 1.20
 - 1.21
 - 1.21.2
+- 1.21.5
 
 ## Mixin Naming Scheme
 

--- a/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
@@ -595,6 +595,26 @@ public class FabricReflectionHelper
 	//Methods:
 
 	/**
+	 * <p>Intemediary name: {@code method_10558}</p>
+	 * <p>Mapped name: {@code getString}</p>
+	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code NbtCompound})</p>
+	 * <p>Descriptor: {@code (Ljava/lang/String;)Ljava/lang/String;}</p>
+	 * <p>Return type: {@code String}</p>
+	 * <p>Parameters types: (String key)</p>
+	 * <p>Static: no</p>
+	 * <p>Versions: 1.14-1.21.4</p>
+	 */
+	public static String NbtCompound_getString_1(NbtCompound instance, String key)
+	{
+		if (_NbtCompound_getString_1Method == null)
+		{
+			_NbtCompound_getString_1Method = lookupMethod("net.minecraft.class_2487", "method_10558", "(Ljava/lang/String;)Ljava/lang/String;", false, false, NbtCompound.class, "getString", String.class, String.class);
+		}
+		return (String)invokeMethod("getString", _NbtCompound_getString_1Method, instance);
+	}
+	private static MethodHandle _NbtCompound_getString_1Method;
+
+	/**
 	 * <p>Intemediary names: {@code method_25441} (1.16+), {@code hasControlDown} (1.14-1.15.x)</p>
 	 * <p>Mapped name: {@code hasControlDown}</p>
 	 * <p>Containing class: {@code net.minecraft.class_437} ({@code net.minecraft.client.gui.screen.Screen})</p>
@@ -962,45 +982,45 @@ public class FabricReflectionHelper
 
 	/**
 	 * <p>Intemediary name: {@code method_68564}</p>
-	 * <p>Mapped name: {@code getStringOr}</p>
+	 * <p>Mapped name: {@code getString}</p>
 	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code NbtCompound})</p>
 	 * <p>Descriptor: {@code (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;}</p>
 	 * <p>Return type: {@code String}</p>
 	 * <p>Parameters types: (String key, String fallback)</p>
-	 * <p>Static: yes</p>
+	 * <p>Static: no</p>
 	 * <p>Versions: 1.21.5+</p>
 	 */
-	public static String NbtCompound_getString_2(String key, String defaultValue)
+	public static String NbtCompound_getString_2(NbtCompound instance, String key, String defaultValue)
 	{
-		if (_NbtCompound_getStringOrMethod == null)
+		if (_NbtCompound_getString_2Method == null)
 		{
-			_triedNbtCompound_getStringOrMethod = true;
-			_NbtCompound_getStringOrMethod = lookupMethod("net.minecraft.class_2487", "method_68564", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", true, false, NbtCompound.class, "getStringOr", String.class, String.class, String.class);
+			_triedNbtCompound_getString_2Method = true;
+			_NbtCompound_getString_2Method = lookupMethod("net.minecraft.class_2487", "method_68564", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", false, false, NbtCompound.class, "getString", String.class, String.class, String.class);
 		}
-		return (String)invokeMethod("getStringOr", _NbtCompound_getStringOrMethod, string, defaultValue);
+		return (String)invokeMethod("getString", _NbtCompound_getString_2Method, instance, key, defaultValue);
 	}
-	private static MethodHandle _NbtCompound_getStringOrMethod;
+	private static MethodHandle _NbtCompound_getString_2Method;
 
 	/**
 	 * <p>Intemediary name: {@code method_68564}</p>
-	 * <p>Mapped name: {@code getStringOr}</p>
+	 * <p>Mapped name: {@code getString}</p>
 	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code net.minecraft.nbt.NbtCompound})</p>
 	 * <p>Descriptor: {@code (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;}</p>
 	 * <p>Return type: {@code String}</p>
 	 * <p>Parameters types: (String key, String defaultValue)</p>
-	 * <p>Static: yes</p>
+	 * <p>Static: no</p>
 	 * <p>Versions: 1.21.5+</p>
 	 */
-	public static boolean Has_NbtCompound_getStringOr()
+	public static boolean Has_NbtCompound_getString_2()
 	{
-		if (!_triedNbtCompound_getStringOrMethod)
+		if (!_triedNbtCompound_getString_2Method)
 		{
-			_triedText_literalMethod = true;
-			_NbtCompound_getStringOrMethod = tryLookupMethod("net.minecraft.class_2487", "method_43470", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", true, false, NbtCompound.class, "getStringOr", String.class, String.class, String.class);
+			_triedNbtCompound_getString_2Method = true;
+			_NbtCompound_getString_2Method = tryLookupMethod("net.minecraft.class_2487", "method_68564", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", false, false, NbtCompound.class, "getString", String.class, String.class, String.class);
 		}
-		return _NbtCompound_getStringOrMethod != null;
+		return _NbtCompound_getString_2Method != null;
 	}
-	private static boolean _triedNbtCompound_getStringOrMethod;
+	private static boolean _triedNbtCompound_getString_2Method;
 
 	//Constructors:
 

--- a/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
@@ -22,6 +22,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.GameOptionsScreen;
 import net.minecraft.client.gui.widget.OptionListWidget;
 import net.minecraft.client.option.GameOptions;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 
@@ -959,6 +960,47 @@ public class FabricReflectionHelper
 	}
 	private static MethodHandle _StringVisitable_getStringMethod;
 
+	/**
+	 * <p>Intemediary name: {@code method_68564}</p>
+	 * <p>Mapped name: {@code getStringOr}</p>
+	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code net.minecraft.nbt.NbtCompound})</p>
+	 * <p>Descriptor: {@code (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;}</p>
+	 * <p>Return type: {@code String}</p>
+	 * <p>Parameters types: (String key, String defaultValue)</p>
+	 * <p>Static: yes</p>
+	 * <p>Versions: 1.21.5+</p>
+	 */
+	public static String NbtCompound_getStringOr(String string, String defaultValue)
+	{
+		if (_NbtCompound_getStringOrMethod == null)
+		{
+			_triedNbtCompound_getStringOrMethod = true;
+			_NbtCompound_getStringOrMethod = lookupMethod("net.minecraft.class_2487", "method_68564", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", true, false, NbtCompound.class, "getStringOr", String.class, String.class, String.class);
+		}
+		return (String)invokeMethod("getStringOr", _NbtCompound_getStringOrMethod, string, defaultValue);
+	}
+	private static MethodHandle _NbtCompound_getStringOrMethod;
+
+	/**
+	 * <p>Intemediary name: {@code method_68564}</p>
+	 * <p>Mapped name: {@code getStringOr}</p>
+	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code net.minecraft.nbt.NbtCompound})</p>
+	 * <p>Descriptor: {@code (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;}</p>
+	 * <p>Return type: {@code String}</p>
+	 * <p>Parameters types: (String key, String defaultValue)</p>
+	 * <p>Static: yes</p>
+	 * <p>Versions: 1.21.5+</p>
+	 */
+	public static boolean Has_NbtCompound_getStringOr()
+	{
+		if (!_triedNbtCompound_getStringOrMethod)
+		{
+			_triedText_literalMethod = true;
+			_NbtCompound_getStringOrMethod = tryLookupMethod("net.minecraft.class_2487", "method_43470", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", true, false, NbtCompound.class, "getStringOr", String.class, String.class, String.class);
+		}
+		return _NbtCompound_getStringOrMethod != null;
+	}
+	private static boolean _triedNbtCompound_getStringOrMethod;
 
 	//Constructors:
 

--- a/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/FabricReflectionHelper.java
@@ -963,14 +963,14 @@ public class FabricReflectionHelper
 	/**
 	 * <p>Intemediary name: {@code method_68564}</p>
 	 * <p>Mapped name: {@code getStringOr}</p>
-	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code net.minecraft.nbt.NbtCompound})</p>
+	 * <p>Containing class: {@code net.minecraft.class_2487} ({@code NbtCompound})</p>
 	 * <p>Descriptor: {@code (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;}</p>
 	 * <p>Return type: {@code String}</p>
-	 * <p>Parameters types: (String key, String defaultValue)</p>
+	 * <p>Parameters types: (String key, String fallback)</p>
 	 * <p>Static: yes</p>
 	 * <p>Versions: 1.21.5+</p>
 	 */
-	public static String NbtCompound_getStringOr(String string, String defaultValue)
+	public static String NbtCompound_getString_2(String key, String defaultValue)
 	{
 		if (_NbtCompound_getStringOrMethod == null)
 		{

--- a/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
@@ -504,6 +504,20 @@ public class ModOptions
 
 	//saving and loading of options:
 
+	private static String getStringSafely(String key, NbtCompound compoundTag)
+	{
+		if (FabricReflectionHelper.Has_NbtCompound_getStringOr())
+		{
+			//1.21.5+
+			return FabricReflectionHelper.NbtCompound_getStringOr(key, "");
+		}
+		else
+		{
+			//1.14-1.21.4
+			return compoundTag.getString(key);
+		}
+	}
+
 	public static File optionsFile;
 
 	@SuppressWarnings("resource")
@@ -536,7 +550,7 @@ public class ModOptions
 				double actualValue = 20.0; //default value
 				try
 				{
-					Double value = Double.parseDouble(compoundTag.getString("trackpadSensitivity"));
+					Double value = Double.parseDouble(getStringSafely("trackpadSensitivity", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -550,7 +564,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(compoundTag.getString("reverseHotbarScrolling"));
+					Boolean value = Boolean.parseBoolean(getStringSafely("reverseHotbarScrolling", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -564,7 +578,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(compoundTag.getString("reverseScrolling"));
+					Boolean value = Boolean.parseBoolean(getStringSafely("reverseScrolling", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -578,7 +592,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(compoundTag.getString("momentumScrolling"));
+					Boolean value = Boolean.parseBoolean(getStringSafely("momentumScrolling", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -592,7 +606,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(compoundTag.getString("interfaceSmoothScroll"));
+					Boolean value = Boolean.parseBoolean(getStringSafely("interfaceSmoothScroll", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -606,7 +620,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(compoundTag.getString("disableCtrlClickFix"));
+					Boolean value = Boolean.parseBoolean(getStringSafely("disableCtrlClickFix", compoundTag));
 					actualValue = value;
 				}
 				catch (Exception ex1)

--- a/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
@@ -506,15 +506,15 @@ public class ModOptions
 
 	private static String getStringHelper(NbtCompound instance, String key)
 	{
-		if (FabricReflectionHelper.Has_NbtCompound_getStringOr())
+		if (FabricReflectionHelper.Has_NbtCompound_getString_2())
 		{
 			//1.21.5+
-			return FabricReflectionHelper.NbtCompound_getStringOr(key, "");
+			return FabricReflectionHelper.NbtCompound_getString_2(instance, key, "");
 		}
 		else
 		{
 			//1.14-1.21.4
-			return compoundTag.getString(key);
+			return FabricReflectionHelper.NbtCompound_getString_1(instance, key);
 		}
 	}
 
@@ -550,7 +550,7 @@ public class ModOptions
 				double actualValue = 20.0; //default value
 				try
 				{
-					Double value = Double.parseDouble(getStringSafely("trackpadSensitivity", compoundTag));
+					Double value = Double.parseDouble(getStringHelper(compoundTag, "trackpadSensitivity"));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -564,7 +564,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(getStringSafely("reverseHotbarScrolling", compoundTag));
+					Boolean value = Boolean.parseBoolean(getStringHelper(compoundTag, "reverseHotbarScrolling"));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -578,7 +578,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(getStringSafely("reverseScrolling", compoundTag));
+					Boolean value = Boolean.parseBoolean(getStringHelper(compoundTag, "reverseScrolling"));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -592,7 +592,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(getStringSafely("momentumScrolling", compoundTag));
+					Boolean value = Boolean.parseBoolean(getStringHelper(compoundTag, "momentumScrolling"));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -606,7 +606,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(getStringSafely("interfaceSmoothScroll", compoundTag));
+					Boolean value = Boolean.parseBoolean(getStringHelper(compoundTag, "interfaceSmoothScroll"));
 					actualValue = value;
 				}
 				catch (Exception ex1)
@@ -620,7 +620,7 @@ public class ModOptions
 				boolean actualValue = false; //default value
 				try
 				{
-					Boolean value = Boolean.parseBoolean(getStringSafely("disableCtrlClickFix", compoundTag));
+					Boolean value = Boolean.parseBoolean(getStringHelper(compoundTag, "disableCtrlClickFix"));
 					actualValue = value;
 				}
 				catch (Exception ex1)

--- a/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
+++ b/src/main/java/com/hamarb123/macos_input_fixes/ModOptions.java
@@ -504,7 +504,7 @@ public class ModOptions
 
 	//saving and loading of options:
 
-	private static String getStringSafely(String key, NbtCompound compoundTag)
+	private static String getStringHelper(NbtCompound instance, String key)
 	{
 		if (FabricReflectionHelper.Has_NbtCompound_getStringOr())
 		{


### PR DESCRIPTION
- Added support for Minecraft 1.21.5
- Implemented compatibility with new `NbtCompound.getStringOr` method
- Created helper method to safely get string values from NBT data
- Updated README to include 1.21.5 in tested versions

This adds support for Mojang's recent [changes to tags](https://github.com/neoforged/.github/blob/main/primers/1.21.5/index.md#tags-and-parsing):
> Getting a value from the tag now returns an `Optional`-wrapped entry, unless you call one of the `get*Or`, where you specify the default value.

Loading the mod in 1.21.5, a crash would occur when reading the options file with `getString`. This issue has been mitigated by calling `getStringOr` with the default value set to an empty string, to replicate previous behavior of `getString` from here on out. This implementation maintains backwards compatibility with previous versions.